### PR TITLE
Adiciona teste de deploy via TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,16 @@ python:
     - "3.3"
     - "3.4"
 install: "pip install -r requirements.txt"
+addons:
+    apt:
+        packages:
+            - sshpass
 script:
     - cd tests && py.test
+after_success:
+    - mkdir build
+    - mv * build
+    - tar -czf package.tgz build
+    - export SSHPASS=$DEPLOY_PASS
+    - sshpass -e scp package.tgz $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH
+    - sshpass -e ssh $DEPLOY_USER@$DEPLOY_HOST $DEPLOY_PATH/deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd `dirname $0`
+
+# Extrair pacote
+tar -xzf package.tgz
+rm package.tgz
+
+# Substituir pacote
+rm -rf GDGAjuBot_old
+mv GDGAjuBot GDGAjuBot_old
+mv build GDGAjuBot


### PR DESCRIPTION
Utilizando do addon sshpass, o script faz o envio do pacote para o servidor configurado no TravisCI e o extrai, instalando dependências e reiniciando o serviço.