### PR TITLE
Melhoria em /book e /events

### DIFF
--- a/gdgajubot.py
+++ b/gdgajubot.py
@@ -104,7 +104,7 @@ class GDGAjuBot:
         logging.info("%s: %s" % (message.from_user.username, "/book"))
         book = self.resources.get_packt_free_book()
         self.bot.send_message(message.chat.id,
-                              "[O livro de hoje é: %s](https://www.packtpub.com/packt/offers/free-learning)." % book,
+                              "O livro de hoje é: [%s](https://www.packtpub.com/packt/offers/free-learning)" % book,
                               parse_mode="Markdown")
 
     def love_ruby(self, message):

--- a/gdgajubot.py
+++ b/gdgajubot.py
@@ -103,9 +103,9 @@ class GDGAjuBot:
         """Retorna o livro disponível no free-learning da editora PacktPub."""
         logging.info("%s: %s" % (message.from_user.username, "/book"))
         book = self.resources.get_packt_free_book()
-        self.bot.send_message(message.chat.id,
-                              "O livro de hoje é: [%s](https://www.packtpub.com/packt/offers/free-learning)" % book,
-                              parse_mode="Markdown", disable_web_page_preview=True)
+        self.bot.reply_to(message,
+                          "O livro de hoje é: [%s](https://www.packtpub.com/packt/offers/free-learning)" % book,
+                          parse_mode="Markdown", disable_web_page_preview=True)
 
     def love_ruby(self, message):
         """Easter Egg com o Ruby."""

--- a/gdgajubot.py
+++ b/gdgajubot.py
@@ -95,7 +95,7 @@ class GDGAjuBot:
                                                event["event_url"]))
 
             response = '\n'.join(response)
-            self.bot.reply_to(message, response)
+            self.bot.reply_to(message, response, disable_web_page_preview=True)
         except Exception as e:
             print(e)
 
@@ -105,7 +105,7 @@ class GDGAjuBot:
         book = self.resources.get_packt_free_book()
         self.bot.send_message(message.chat.id,
                               "O livro de hoje é: [%s](https://www.packtpub.com/packt/offers/free-learning)" % book,
-                              parse_mode="Markdown")
+                              parse_mode="Markdown", disable_web_page_preview=True)
 
     def love_ruby(self, message):
         """Easter Egg com o Ruby."""


### PR DESCRIPTION
Tanto `/book` quanto `/events` agora não exibem pré-visualização.

A resposta de `/book` alterou levemente, agora o link está somente no livro e referencia a mensagem com o comando.