### PR TITLE
Corrigido bug quando os events já estão em cache

### DIFF
--- a/gdgajubot.py
+++ b/gdgajubot.py
@@ -89,7 +89,7 @@ class GDGAjuBot:
             self.bot.reply_to(message, '\n'.join(response),
                               parse_mode="Markdown", disable_web_page_preview=True)
         except Exception as e:
-            print(e)
+            logging.exception(e)
 
     def packtpub_free_learning(self, message):
         """Retorna o livro disponível no free-learning da editora PacktPub."""

--- a/gdgajubot.py
+++ b/gdgajubot.py
@@ -77,13 +77,17 @@ class GDGAjuBot:
             last_events = self.resources.get_events(5)
             response = []
             for event in last_events:
-                # convert time returned by Meetup API
-                event_dt = datetime.datetime.utcfromtimestamp(event['time'] / 1000)
-                # adjust time to UTC-3
-                event_dt -= datetime.timedelta(hours=3)
+                # If the events wasn't in cache, event['time'] is a timestamp.
+                # So we format it!
+                if isinstance(event['time'], int):
+                    # convert time returned by Meetup API
+                    event_dt = datetime.datetime.utcfromtimestamp(event['time'] / 1000)
+                    # adjust time to UTC-3
+                    event_dt -= datetime.timedelta(hours=3)
 
-                # create a pretty-looking date
-                event['time'] = event_dt.strftime('%d/%m %H:%M')
+                    # create a pretty-looking date
+                    event['time'] = event_dt.strftime('%d/%m %H:%M')
+
                 response.append("[%(name)s](%(link)s): %(time)s" % event)
 
             self.bot.reply_to(message, '\n'.join(response),

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -39,33 +39,36 @@ class MockMessage:
 
 
 class MockResources:
+    # Falso cache de eventos
+    cache_events = [
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229313880/',
+         'name': 'Hackeando sua Carreira #Hangout',
+         'time': 1459378800000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229623381/',
+         'name': 'Android Jam 2: Talks Dia 2',
+         'time': 1459612800000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/',
+         'name': 'Coding Dojo',
+         'time': 1459980000000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229591464/',
+         'name': 'O Caminho para uma Arquitetura Elegante #Hangout',
+         'time': 1460160000000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229770309/',
+         'name': 'Android Jam 2: #Curso Dia 2',
+         'time': 1460217600000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvhbgb/',
+         'name': 'Coding Dojo',
+         'time': 1462399200000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951204/',
+         'name': 'Google I/O Extended',
+         'time': 1463587200000},
+        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951264/',
+         'name': 'Google IO Extended 2016',
+         'time': 1463608800000},
+    ]
+
     def get_events(self, n):
-        return [
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229313880/',
-             'name': 'Hackeando sua Carreira #Hangout',
-             'time': 1459378800000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229623381/',
-             'name': 'Android Jam 2: Talks Dia 2',
-             'time': 1459612800000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/',
-             'name': 'Coding Dojo',
-             'time': 1459980000000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229591464/',
-             'name': 'O Caminho para uma Arquitetura Elegante #Hangout',
-             'time': 1460160000000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229770309/',
-             'name': 'Android Jam 2: #Curso Dia 2',
-             'time': 1460217600000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvhbgb/',
-             'name': 'Coding Dojo',
-             'time': 1462399200000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951204/',
-             'name': 'Google I/O Extended',
-             'time': 1463587200000},
-            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951264/',
-             'name': 'Google IO Extended 2016',
-             'time': 1463608800000},
-        ][:n]
+        return self.cache_events[:n]
 
     def get_packt_free_book(self):
         return "Android 2099"
@@ -107,8 +110,15 @@ class TestGDGAjuBot(unittest.TestCase):
              "[Coding Dojo](http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/): 06/04 19:00\n"
              "[O Caminho para uma Arquitetura Elegante #Hangout](http://www.meetup.com/GDG-Aracaju/events/229591464/): 08/04 21:00\n"
              "[Android Jam 2: #Curso Dia 2](http://www.meetup.com/GDG-Aracaju/events/229770309/): 09/04 13:00")
+
+        # Verifica se o response criado está correto
         self.assertEqual(bot.calls[-1],
                          CALL.reply_to(message, r, parse_mode="Markdown", disable_web_page_preview=True))
+
+        # Garante que o cache mutável não gerará uma exceção
+        n_calls = len(bot.calls)
+        g_bot.list_upcoming_events(message)
+        self.assertGreater(len(bot.calls), n_calls)
 
     def test_packtpub_free_learning(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()


### PR DESCRIPTION
O problema era que eu substituí `event['time']`, que era um `int` pela versão formatada:

```
'%d/%m %H:%M'
```

Isso ocorre porque o cache é mutável, estranho, mas deve ser efeito do tipo ser *memory*.

Eu corrigi verificando antes se `event['time']` já não estava formatado (i.e. se é um `int`).