### PR TITLE
Adicionado utilitários para definir o bot + testes

### DIFF
--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -60,6 +60,7 @@ find_python = re.compile(r"(?i)\bPYTHON\b").search
 
 # Helper para definir os comandos do bot
 handler = util.HandlerHelper()
+commands = handler.commands
 
 
 class GDGAjuBot:
@@ -69,13 +70,13 @@ class GDGAjuBot:
         self.config = config
         bot.set_update_listener(self.handle_messages)
 
-    @handler.commands('/start', '/help')
+    @commands('/start', '/help')
     def send_welcome(self, message):
         """Mensagem de apresentação do bot."""
         logging.info("/start")
         self.bot.reply_to(message, "Este bot faz buscas no Meetup do %s" % (self.config["group_name"]))
 
-    @handler.commands('/events')
+    @commands('/events')
     def list_upcoming_events(self, message):
         """Retorna a lista de eventos do Meetup."""
         logging.info("%s: %s" % (message.from_user.username, "/events"))
@@ -101,7 +102,7 @@ class GDGAjuBot:
         except Exception as e:
             logging.exception(e)
 
-    @handler.commands('/book')
+    @commands('/book')
     def packtpub_free_learning(self, message):
         """Retorna o livro disponível no free-learning da editora PacktPub."""
         logging.info("%s: %s" % (message.from_user.username, "/book"))
@@ -109,6 +110,11 @@ class GDGAjuBot:
         self.bot.reply_to(message,
                           "O livro de hoje é: [%s](https://www.packtpub.com/packt/offers/free-learning)" % book,
                           parse_mode="Markdown", disable_web_page_preview=True)
+
+    @commands('/changelog')
+    def changelog(self, message):
+        logging.info("%s: %s" % (message.from_user.username, "/changelog"))
+        self.bot.send_message(message.chat.id, "https://github.com/GDGAracaju/GDGAjuBot/blob/master/CHANGELOG.md")
 
     def love_ruby(self, message):
         """Easter Egg com o Ruby."""
@@ -125,11 +131,6 @@ class GDGAjuBot:
         """Easter Egg com o Python."""
         logging.info("%s: %s" % (message.from_user.username, "python"))
         self.bot.send_message(message.chat.id, "import antigravity")
-
-    @handler.commands('/changelog')
-    def changelog(self, message):
-        logging.info("%s: %s" % (message.from_user.username, "/changelog"))
-        self.bot.send_message(message.chat.id, "https://github.com/GDGAracaju/GDGAjuBot/blob/master/CHANGELOG.md")
 
     def handle_messages(self, messages):
         for message in messages:

--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -12,7 +12,7 @@ from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
 from bs4 import BeautifulSoup
 
-from gdgajubot import util
+from . import util
 
 
 class Resources:

--- a/gdgajubot/util.py
+++ b/gdgajubot/util.py
@@ -1,0 +1,50 @@
+import logging
+import re
+
+
+class HandlerHelper:
+    def __init__(self):
+        self.map_commands = {}
+
+    def commands(self, *names):
+        """Decorator para marcar funções como comandos do bot"""
+        def decorator(func):
+            def wrapped(*args, **kwargs):
+                return func(*args, **kwargs)
+            for name in names:
+                self.map_commands[name] = func
+            return wrapped
+        return decorator
+
+    def handle_command(self, name, *args, raises=False, **kwargs):
+        """Executa a função associada ao comando passado
+
+        :except: Exceções são relançadas se `raises` é `True`, do contrário, são enviadas ao log.
+        :return: `True` ou `False` indicando que o comando foi executado
+        """
+        function = self.map_commands.get(name)
+        if function:
+            try:
+                function(*args, **kwargs)
+            except Exception as e:
+                raise e if raises else logging.exception(e)
+            return True
+        return False
+
+
+def match_command(text):
+    """Verifica se o texto passado representa um comando
+
+    :return: um objeto regex match ou `None`
+    """
+    return re.match(r'(/[^\s]+ ?[^\s]+(?:\s+[^\s]+)*)', text)
+
+
+def extract_command(text):
+    """Extrai o nome do comando, incluindo a barra '/'
+
+    :return: nome do comando ou `None`
+    """
+    match = match_command(text)
+    if match:
+        return match.group(1).split()[0].split('@')[0]

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -154,6 +154,40 @@ class TestGDGAjuBot(unittest.TestCase):
         r = "https://github.com/GDGAracaju/GDGAjuBot/blob/master/CHANGELOG.md"
         self.assertEqual(called, CALL.send_message(message.chat.id, r))
 
+    # Routing test
+
+    def test_handle_messages(self):
+        bot, resources = MockTeleBot(), MockResources()
+        g_bot = gdgajubot.GDGAjuBot(bot, resources, self.config)
+
+        # test simple commands text
+        commands_asserts = {
+            '/events': self._assert_list_upcoming_events,
+            '/start': self._assert_send_welcome,
+            '/changelog': self._assert_changelog,
+            '/book': self._assert_packtpub_free_learning,
+            '/help': self._assert_send_welcome,
+        }
+        messages = [MockMessage(id=i, text=cmd, content_type="text")
+                    for i, cmd in enumerate(commands_asserts)]
+        for i, _assert in enumerate(commands_asserts.values()):
+            g_bot.handle_messages(messages[i:i+1])
+            _assert(bot.calls[-1], messages[i])
+
+        # test qualifying commands text
+        commands_asserts = {
+            '/events@gdgajubot': self._assert_list_upcoming_events,
+            '/start@erickbot': self._assert_send_welcome,
+            '/changelog@wagnerbot': self._assert_changelog,
+            '/book@brandinibot': self._assert_packtpub_free_learning,
+            '/help@thalesbot': self._assert_send_welcome,
+        }
+        messages = [MockMessage(id=i, text=cmd, content_type="text")
+                    for i, cmd in enumerate(commands_asserts)]
+        for i, _assert in enumerate(commands_asserts.values()):
+            g_bot.handle_messages(messages[i:i+1])
+            _assert(bot.calls[-1], messages[i])
+
 
 class TestResources(unittest.TestCase):
     cd = os.path.dirname(__file__)

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -77,6 +77,8 @@ class MockResources:
 
 
 class TestGDGAjuBot(unittest.TestCase):
+    config = {'group_name': 'Test-Bot'}
+
     # Regular expressions tests
 
     def test_find_ruby(self):
@@ -101,25 +103,17 @@ class TestGDGAjuBot(unittest.TestCase):
 
     def test_send_welcome(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()
-        config = {'group_name': 'Test-Bot'}
-        g_bot = gdgajubot.GDGAjuBot(bot, resources, config)
+        g_bot = gdgajubot.GDGAjuBot(bot, resources, self.config)
         g_bot.send_welcome(message)
-        self.assertEqual(bot.calls[-1],
-                         CALL.reply_to(message, "Este bot faz buscas no Meetup do Test-Bot"))
+        self._assert_send_welcome(bot.calls[-1], message)
 
     def test_list_upcoming_events(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()
-        g_bot = gdgajubot.GDGAjuBot(bot, resources, {})
+        g_bot = gdgajubot.GDGAjuBot(bot, resources, self.config)
         g_bot.list_upcoming_events(message)
-        r = ("[Hackeando sua Carreira #Hangout](http://www.meetup.com/GDG-Aracaju/events/229313880/): 30/03 20:00\n"
-             "[Android Jam 2: Talks Dia 2](http://www.meetup.com/GDG-Aracaju/events/229623381/): 02/04 13:00\n"
-             "[Coding Dojo](http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/): 06/04 19:00\n"
-             "[O Caminho para uma Arquitetura Elegante #Hangout](http://www.meetup.com/GDG-Aracaju/events/229591464/): 08/04 21:00\n"
-             "[Android Jam 2: #Curso Dia 2](http://www.meetup.com/GDG-Aracaju/events/229770309/): 09/04 13:00")
 
         # Verifica se o response criado está correto
-        self.assertEqual(bot.calls[-1],
-                         CALL.reply_to(message, r, parse_mode="Markdown", disable_web_page_preview=True))
+        self._assert_list_upcoming_events(bot.calls[-1], message)
 
         # Garante que o cache mutável não gerará uma exceção
         n_calls = len(bot.calls)
@@ -128,18 +122,37 @@ class TestGDGAjuBot(unittest.TestCase):
 
     def test_packtpub_free_learning(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()
-        g_bot = gdgajubot.GDGAjuBot(bot, resources, {})
+        g_bot = gdgajubot.GDGAjuBot(bot, resources, self.config)
         g_bot.packtpub_free_learning(message)
-        r = "O livro de hoje é: [Android 2099](https://www.packtpub.com/packt/offers/free-learning)"
-        self.assertEqual(bot.calls[-1],
-                         CALL.reply_to(message, r, parse_mode="Markdown", disable_web_page_preview=True))
+        self._assert_packtpub_free_learning(bot.calls[-1], message)
 
     def test_changelog(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage(id=0xB00B)
-        g_bot = gdgajubot.GDGAjuBot(bot, resources, {})
+        g_bot = gdgajubot.GDGAjuBot(bot, resources, self.config)
         g_bot.changelog(message)
+        self._assert_changelog(bot.calls[-1], message)
+
+    def _assert_send_welcome(self, called, message):
+        self.assertEqual(called,
+                         CALL.reply_to(message, "Este bot faz buscas no Meetup do Test-Bot"))
+
+    def _assert_list_upcoming_events(self, called, message):
+        r = ("[Hackeando sua Carreira #Hangout](http://www.meetup.com/GDG-Aracaju/events/229313880/): 30/03 20:00\n"
+             "[Android Jam 2: Talks Dia 2](http://www.meetup.com/GDG-Aracaju/events/229623381/): 02/04 13:00\n"
+             "[Coding Dojo](http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/): 06/04 19:00\n"
+             "[O Caminho para uma Arquitetura Elegante #Hangout](http://www.meetup.com/GDG-Aracaju/events/229591464/): 08/04 21:00\n"
+             "[Android Jam 2: #Curso Dia 2](http://www.meetup.com/GDG-Aracaju/events/229770309/): 09/04 13:00")
+        self.assertEqual(called,
+                         CALL.reply_to(message, r, parse_mode="Markdown", disable_web_page_preview=True))
+
+    def _assert_packtpub_free_learning(self, called, message):
+        r = "O livro de hoje é: [Android 2099](https://www.packtpub.com/packt/offers/free-learning)"
+        self.assertEqual(called,
+                         CALL.reply_to(message, r, parse_mode="Markdown", disable_web_page_preview=True))
+
+    def _assert_changelog(self, called, message):
         r = "https://github.com/GDGAracaju/GDGAjuBot/blob/master/CHANGELOG.md"
-        self.assertEqual(bot.calls[-1], CALL.send_message(message.chat.id, r))
+        self.assertEqual(called, CALL.send_message(message.chat.id, r))
 
 
 class TestResources(unittest.TestCase):

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -3,7 +3,6 @@ import sys
 
 sys.path.append('../')
 
-import time
 import unittest
 import os
 from gdgajubot import gdgajubot
@@ -33,8 +32,11 @@ class MockTeleBot:
 
 
 class MockMessage:
+    def __init__(self, **kwargs):
+        self.__dict__.update(**kwargs)
+
     # Método definido para não ter AttributeError
-    def __getattribute__(self, item):
+    def __getattr__(self, item):
         return self
 
 
@@ -75,6 +77,8 @@ class MockResources:
 
 
 class TestGDGAjuBot(unittest.TestCase):
+    # Regular expressions tests
+
     def test_find_ruby(self):
         assert gdgajubot.find_ruby("Olá ruby GDG")
         assert gdgajubot.find_ruby("Olá RUBY GDG")
@@ -92,6 +96,8 @@ class TestGDGAjuBot(unittest.TestCase):
         assert gdgajubot.find_python("Olá Python GDG")
         assert gdgajubot.find_python("Olá PYTHON GDG")
         assert not gdgajubot.find_python("OlápythonGDG")
+
+    # Bot commands tests
 
     def test_send_welcome(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()
@@ -127,6 +133,13 @@ class TestGDGAjuBot(unittest.TestCase):
         r = "O livro de hoje é: [Android 2099](https://www.packtpub.com/packt/offers/free-learning)"
         self.assertEqual(bot.calls[-1],
                          CALL.reply_to(message, r, parse_mode="Markdown", disable_web_page_preview=True))
+
+    def test_changelog(self):
+        bot, resources, message = MockTeleBot(), MockResources(), MockMessage(id=0xB00B)
+        g_bot = gdgajubot.GDGAjuBot(bot, resources, {})
+        g_bot.changelog(message)
+        r = "https://github.com/GDGAracaju/GDGAjuBot/blob/master/CHANGELOG.md"
+        self.assertEqual(bot.calls[-1], CALL.send_message(message.chat.id, r))
 
 
 class TestResources(unittest.TestCase):


### PR DESCRIPTION
- Decorator para associar funções a comandos
- Função `extract_command` própria, que extrai baseado em regex e conserva a barra '/'.
- Testes cobrindo `GDGAjuBot`, inclusive o roteamento para os métodos, feito por `handle_messages`.