### PR TITLE
Usando datetime com fuso horário (tzinfo) e ajustes na leitura dos argumentos

### DIFF
--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -121,9 +121,7 @@ class GDGAjuBot:
             # So we format it!
             if isinstance(event['time'], int):
                 # convert time returned by Meetup API
-                event_dt = datetime.datetime.utcfromtimestamp(event['time'] / 1000)
-                # adjust time to UTC-3
-                event_dt -= datetime.timedelta(hours=3)
+                event_dt = datetime.datetime.fromtimestamp(event['time'] / 1000, tz=util.AJU_TZ)
 
                 # create a pretty-looking date
                 event['time'] = event_dt.strftime('%d/%m %H:%M')
@@ -146,11 +144,10 @@ class GDGAjuBot:
                 (3600, '1 hora'))
 
     def _book_response(self, book, expires, now=None):
-        _3h = datetime.timedelta(hours=3)
         if now is None:
-            now = datetime.datetime.utcnow() - _3h
+            now = datetime.datetime.now(tz=util.AJU_TZ)
 
-        delta = (datetime.datetime.utcfromtimestamp(expires) - _3h) - now
+        delta = datetime.datetime.fromtimestamp(expires, tz=util.AJU_TZ) - now
         seconds = delta.total_seconds()
 
         response = "O livro de hoje é: [%s](https://www.packtpub.com/packt/offers/free-learning)" % book

--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -233,7 +233,8 @@ def main():
     parser.add_argument('-t', '--telegram_token', help='Token da API do Telegram', required=True)
     parser.add_argument('-m', '--meetup_key', help='Key da API do Meetup', required=True)
     parser.add_argument('-g', '--group_name', help='Grupo do Meetup', required=True)
-    parser.add_argument('-d', '--dev', help='Indicador de Debug/Dev mode. Valores: True/False')
+    parser.add_argument('-d', '--dev', help='Indicador de Debug/Dev mode', action='store_true')
+    parser.add_argument('--no-dev', help=argparse.SUPPRESS, dest='dev', action='store_false')
 
     # Get required arguments to check after parsed
     required_actions = []
@@ -256,7 +257,7 @@ def main():
 
     # Starting bot
     logging.info("Iniciando bot")
-    if _config["dev"].lower() == "true":
+    if _config["dev"]:
         logging.info("Dev mode activated.")
         logging.info("Usando telegram_token=%s" % (_config["telegram_token"]))
         logging.info("Usando meetup_key=%s" % (_config["meetup_key"]))

--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -230,10 +230,19 @@ def main():
     # Configuring bot parameters
     logging.info("Configurando parâmetros")
     parser = argparse.ArgumentParser(description='Bot do GDG Aracaju')
-    parser.add_argument('-t', '--telegram_token', help='Token da API do Telegram')
-    parser.add_argument('-m', '--meetup_key', help='Key da API do Meetup')
-    parser.add_argument('-g', '--group_name', help='Grupo do Meetup')
+    parser.add_argument('-t', '--telegram_token', help='Token da API do Telegram', required=True)
+    parser.add_argument('-m', '--meetup_key', help='Key da API do Meetup', required=True)
+    parser.add_argument('-g', '--group_name', help='Grupo do Meetup', required=True)
     parser.add_argument('-d', '--dev', help='Indicador de Debug/Dev mode. Valores: True/False')
+
+    # Get required arguments to check after parsed
+    required_actions = []
+    for action in parser._actions:
+        if action.required:
+            required_actions.append(action)
+            action.required = False
+
+    # Parse command line args
     namespace = parser.parse_args()
 
     # Mounting config
@@ -241,11 +250,9 @@ def main():
                for k, v in vars(namespace).items()}
 
     # Verifying required arguments
-    missing_args = [k.upper() for k, v in _config.items() if not v]
+    missing_args = [argparse._get_action_name(a) for a in required_actions if not _config[a.dest]]
     if missing_args:
-        import sys
-        print("error: missing arguments:", ", ".join(missing_args), file=sys.stderr)
-        exit(1)
+        parser.error("missing arguments: " + ", ".join(missing_args))
 
     # Starting bot
     logging.info("Iniciando bot")

--- a/gdgajubot/util.py
+++ b/gdgajubot/util.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import re
 
@@ -48,3 +49,33 @@ def extract_command(text):
     match = match_command(text)
     if match:
         return match.group(1).split()[0].split('@')[0]
+
+
+class TimeZone:
+    class TZ(datetime.tzinfo):
+        ZERO = datetime.timedelta(0)
+
+        def __init__(self, hours):
+            self._utcoffset = datetime.timedelta(hours=hours)
+            self._tzname = 'GMT%d' % hours
+
+        def utcoffset(self, dt):
+            return self._utcoffset
+
+        def tzname(self, dt):
+            return self._tzname
+
+        def dst(self, dt):
+            return self.ZERO
+
+    # cache de fusos horários
+    timezones = {}
+
+    @classmethod
+    def gmt(cls, hours):
+        if hours not in cls.timezones:
+            cls.timezones[hours] = cls.TZ(hours)
+        return cls.timezones[hours]
+
+# aliases úteis
+AJU_TZ = TimeZone.gmt(-3)

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -5,9 +5,10 @@ sys.path.append('../')
 
 import unittest
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from gdgajubot import gdgajubot
+from gdgajubot.util import AJU_TZ
 
 
 class MetaCall:
@@ -130,26 +131,25 @@ class TestGDGAjuBot(unittest.TestCase):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()
         g_bot = gdgajubot.GDGAjuBot(bot, resources, self.config)
         ts = resources.bookts
-        _3h = timedelta(hours=3)
 
         # Sem warning
-        g_bot.packtpub_free_learning(message, now=datetime.utcfromtimestamp(ts - 10*3600))
+        g_bot.packtpub_free_learning(message, now=datetime.fromtimestamp(ts - 10*3600, tz=AJU_TZ))
         self._assert_packtpub_free_learning(bot.calls[-1], message)
 
         # Os próximos testes verificam cada um dos warnings
-        g_bot.packtpub_free_learning(message, now=datetime.utcfromtimestamp(ts - 59*60) - _3h)
+        g_bot.packtpub_free_learning(message, now=datetime.fromtimestamp(ts - 59*60, tz=AJU_TZ))
         self._assert_packtpub_free_learning(bot.calls[-1], message, warning="\n\nFaltam menos de 1 hora!")
 
-        g_bot.packtpub_free_learning(message, now=datetime.utcfromtimestamp(ts - 29*60) - _3h)
+        g_bot.packtpub_free_learning(message, now=datetime.fromtimestamp(ts - 29*60, tz=AJU_TZ))
         self._assert_packtpub_free_learning(bot.calls[-1], message, warning="\n\nFaltam menos de meia hora!")
 
-        g_bot.packtpub_free_learning(message, now=datetime.utcfromtimestamp(ts - 9*60) - _3h)
+        g_bot.packtpub_free_learning(message, now=datetime.fromtimestamp(ts - 9*60, tz=AJU_TZ))
         self._assert_packtpub_free_learning(bot.calls[-1], message, warning="\n\nFaltam menos de 10 minutos!")
 
-        g_bot.packtpub_free_learning(message, now=datetime.utcfromtimestamp(ts - 59) - _3h)
+        g_bot.packtpub_free_learning(message, now=datetime.fromtimestamp(ts - 59, tz=AJU_TZ))
         self._assert_packtpub_free_learning(bot.calls[-1], message, warning="\n\nFaltam menos de 1 minuto!")
 
-        g_bot.packtpub_free_learning(message, now=datetime.utcfromtimestamp(ts - 29) - _3h)
+        g_bot.packtpub_free_learning(message, now=datetime.fromtimestamp(ts - 29, tz=AJU_TZ))
         self._assert_packtpub_free_learning(bot.calls[-1], message, warning="\n\nFaltam menos de 30 segundos!")
 
     def test_changelog(self):


### PR DESCRIPTION
Com a alteração no datetime não há mais confusão com as horas UTC. Agora todas são GMT-3, podendo serem convertidas para qualquer outra zona facilmente, se necessário.

Sobre os argumentos, o código anterior considerava todos os argumentos requeridos. Os ajustes consideram a marcação feita com `parser.add_argument`.

Ainda nos argumentos, modifiquei o argumento para ativar o modo de desenvolvimento da seguinte forma:

| De            | Para       |
|---------------|------------|
| `--dev True`  | `--dev`    |
| `--dev False` | `--no-dev` |