### PR TITLE
Refatoração no módulo de testes

### DIFF
--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -130,9 +130,11 @@ class TestGDGAjuBot(unittest.TestCase):
         self._assert_changelog(bot, message)
 
     def _assert_send_welcome(self, bot, message):
+        self._assert_mockbot(bot)
         bot.reply_to.assert_called_with(message, "Este bot faz buscas no Meetup do Test-Bot")
 
     def _assert_list_upcoming_events(self, bot, message):
+        self._assert_mockbot(bot)
         r = ("[Hackeando sua Carreira #Hangout](http://www.meetup.com/GDG-Aracaju/events/229313880/): 30/03 20:00\n"
              "[Android Jam 2: Talks Dia 2](http://www.meetup.com/GDG-Aracaju/events/229623381/): 02/04 13:00\n"
              "[Coding Dojo](http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/): 06/04 19:00\n"
@@ -141,12 +143,17 @@ class TestGDGAjuBot(unittest.TestCase):
         bot.reply_to.assert_called_with(message, r, parse_mode="Markdown", disable_web_page_preview=True)
 
     def _assert_packtpub_free_learning(self, bot, message, warning=''):
+        self._assert_mockbot(bot)
         r = "O livro de hoje é: [Android 2099](https://www.packtpub.com/packt/offers/free-learning)" + warning
         bot.reply_to.assert_called_with(message, r, parse_mode="Markdown", disable_web_page_preview=True)
 
     def _assert_changelog(self, bot, message):
+        self._assert_mockbot(bot)
         r = "https://github.com/GDGAracaju/GDGAjuBot/blob/master/CHANGELOG.md"
         bot.send_message.assert_called_with(message.chat.id, r)
+
+    def _assert_mockbot(self, bot):
+        self.assertIsInstance(bot, MockTeleBot)
 
     # Internals tests
 

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
-
-sys.path.append('../')
-
 import unittest
 import os
 from datetime import datetime

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -26,33 +26,34 @@ MockMessage = mock.NonCallableMock
 
 
 class MockResources:
-    # Falso cache de eventos
-    cache_events = [
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229313880/',
-         'name': 'Hackeando sua Carreira #Hangout',
-         'time': 1459378800000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229623381/',
-         'name': 'Android Jam 2: Talks Dia 2',
-         'time': 1459612800000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/',
-         'name': 'Coding Dojo',
-         'time': 1459980000000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229591464/',
-         'name': 'O Caminho para uma Arquitetura Elegante #Hangout',
-         'time': 1460160000000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229770309/',
-         'name': 'Android Jam 2: #Curso Dia 2',
-         'time': 1460217600000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvhbgb/',
-         'name': 'Coding Dojo',
-         'time': 1462399200000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951204/',
-         'name': 'Google I/O Extended',
-         'time': 1463587200000},
-        {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951264/',
-         'name': 'Google IO Extended 2016',
-         'time': 1463608800000},
-    ]
+    def __init__(self):
+        # Falso cache de eventos
+        self.cache_events = [
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229313880/',
+             'name': 'Hackeando sua Carreira #Hangout',
+             'time': 1459378800000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229623381/',
+             'name': 'Android Jam 2: Talks Dia 2',
+             'time': 1459612800000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvgbjb/',
+             'name': 'Coding Dojo',
+             'time': 1459980000000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229591464/',
+             'name': 'O Caminho para uma Arquitetura Elegante #Hangout',
+             'time': 1460160000000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229770309/',
+             'name': 'Android Jam 2: #Curso Dia 2',
+             'time': 1460217600000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/mwnsrlyvhbgb/',
+             'name': 'Coding Dojo',
+             'time': 1462399200000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951204/',
+             'name': 'Google I/O Extended',
+             'time': 1463587200000},
+            {'link': 'http://www.meetup.com/GDG-Aracaju/events/229951264/',
+             'name': 'Google IO Extended 2016',
+             'time': 1463608800000},
+        ]
 
     def get_events(self, n):
         return self.cache_events[:n]


### PR DESCRIPTION
Principais alterações:

- Remove necessidade de `sys.path.append()`
- Utilizando framework de mocks da biblioteca padrão (pacote `unittest.mock`)