### PR TITLE
Respostas aleatórias para comandos repetidos

### DIFF
--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -285,7 +285,7 @@ class GDGAjuBot:
                 )
         else:
             response = 'Não existem links associados a esse grupo.'
-        self._smart_reply(
+        self._send_smart_reply(
             message, response,
             parse_mode="Markdown", disable_web_page_preview=True)
 
@@ -300,7 +300,7 @@ class GDGAjuBot:
             else:
                 response = "Não há nenhum futuro evento do grupo {0}.".format(
                     self.config.group_name)
-            self._smart_reply(
+            self._send_smart_reply(
                 message, response,
                 parse_mode="Markdown", disable_web_page_preview=True
             )
@@ -330,7 +330,7 @@ class GDGAjuBot:
         # por questões de possível cache antigo.
         for _ in range(2):
             book = self.resources.get_packt_free_book()
-            response = self._book_response(book, now)
+            response = self._create_book_response(book, now)
             if response:
                 break
             Resources.cache.invalidate(
@@ -339,7 +339,7 @@ class GDGAjuBot:
         else:
             response = "Parece que não tem um livro grátis hoje 😡\n\n" \
                        "Se acha que é um erro meu, veja com seus próprios olhos em " + Resources.BOOK_URL
-        self._smart_reply(
+        self._send_smart_reply(
             message, response,
             parse_mode="Markdown", disable_web_page_preview=True,
             send_picture=book['cover'] if book else None
@@ -351,7 +351,7 @@ class GDGAjuBot:
                 (1800, 'meia hora'),
                 (3600, '1 hora'))
 
-    def _book_response(self, book, now=None):
+    def _create_book_response(self, book, now=None):
         if book is None:
             return
 
@@ -376,8 +376,8 @@ class GDGAjuBot:
                 return response + warning
         return response
 
-    def _smart_reply(self, message, text, **kwargs):
-        def send_book():
+    def _send_smart_reply(self, message, text, **kwargs):
+        def send_message():
             picture = kwargs.get('send_picture')
             if picture:
                 self.bot.send_photo(chat_id=message.chat_id, photo=picture)
@@ -400,13 +400,13 @@ class GDGAjuBot:
                 )
             # or, send new response and update the cache
             else:
-                sent = send_book()
+                sent = send_message()
                 previous.update({'text': text, 'message_id': sent.message_id})
                 previous_cache[message.chat.id] = previous  # reset expire time
 
         # On private chats or channels, send the normal reply...
         else:
-            send_book()
+            send_message()
 
     @commands('/about')
     def about(self, message):

--- a/gdgajubot/gdgajubot.py
+++ b/gdgajubot/gdgajubot.py
@@ -4,6 +4,7 @@ import argparse
 import datetime
 import functools
 import logging
+import random
 import re
 
 import requests
@@ -376,6 +377,12 @@ class GDGAjuBot:
                 return response + warning
         return response
 
+    already_answered_texts = (
+        "Ei, olhe, acabei de responder!",
+        "Me reservo ao direito de não responder!",
+        "Deixe de insistência!",
+    )
+
     def _send_smart_reply(self, message, text, **kwargs):
         def send_message():
             picture = kwargs.get('send_picture')
@@ -395,7 +402,7 @@ class GDGAjuBot:
             # to send a contextual response
             if previous.get('text') == text:
                 self.bot.send_message(
-                    message.chat.id, "Clique para ver a última resposta",
+                    message.chat.id, random.choice(self.already_answered_texts),
                     reply_to_message_id=previous['message_id']
                 )
             # or, send new response and update the cache

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -221,8 +221,10 @@ class TestGDGAjuBot(unittest.TestCase):
         g_bot._send_smart_reply(message, text)
         bot.reply_to.assert_called_with(message, text)
         g_bot._send_smart_reply(message, text)
-        bot.send_message.assert_called_with(message.chat.id, "Clique para ver a última resposta",
+        bot.send_message.assert_called_with(message.chat.id, mock.ANY,
                                             reply_to_message_id=82)
+        the_answer = bot.send_message.call_args[0][1]
+        assert the_answer in gdgajubot.GDGAjuBot.already_answered_texts
 
 
 class TestResources(unittest.TestCase):

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -114,7 +114,7 @@ class TestGDGAjuBot(unittest.TestCase):
         # Garante que o cache mutável não gerará uma exceção
         n_calls = len(bot.method_calls)
         g_bot.list_upcoming_events(message)
-        self.assertGreater(len(bot.method_calls), n_calls)
+        assert len(bot.method_calls) > n_calls
 
     def test_packtpub_free_learning(self):
         bot, resources, message = MockTeleBot(), MockResources(), MockMessage()
@@ -196,7 +196,7 @@ class TestGDGAjuBot(unittest.TestCase):
         assert link in response
 
     def _assert_mockbot(self, bot):
-        self.assertIsInstance(bot, MockTeleBot)
+        assert isinstance(bot, MockTeleBot)
 
     # Internals tests
 
@@ -230,8 +230,9 @@ class TestResources(unittest.TestCase):
 
     def test_extract_packt_free_book(self):
         content = open(os.path.join(self.cd, 'packtpub-free-learning.html.fixture'), 'rb')
-        self.assertEqual(gdgajubot.Resources.extract_packt_free_book(content),
-                         {'name': "Oracle Enterprise Manager 12c Administration Cookbook",
-                          'summary': "Over 50 practical recipes to install, configure, and monitor your Oracle setup using Oracle Enterprise Manager",
-                          'cover': "https://d1ldz4te4covpm.cloudfront.net/sites/default/files/imagecache/dotd_main_image/7409EN.jpg",
-                          'expires': 1459378800})
+        result = {'name': "Oracle Enterprise Manager 12c Administration Cookbook",
+                  'summary': "Over 50 practical recipes to install, configure, and monitor your Oracle setup using Oracle Enterprise Manager",
+                  'cover': "https://d1ldz4te4covpm.cloudfront.net/sites/default/files/imagecache/dotd_main_image/7409EN.jpg",
+                  'expires': 1459378800}
+
+        assert gdgajubot.Resources.extract_packt_free_book(content) == result

--- a/tests/test_gdgajubot.py
+++ b/tests/test_gdgajubot.py
@@ -208,9 +208,9 @@ class TestGDGAjuBot(unittest.TestCase):
 
         # Mensagens privadas não fazem link
         message.chat.type = "private"
-        g_bot._smart_reply(message, text)
+        g_bot._send_smart_reply(message, text)
         bot.reply_to.assert_called_with(message, text)
-        g_bot._smart_reply(message, text)
+        g_bot._send_smart_reply(message, text)
         bot.reply_to.assert_called_with(message, text)
 
         # Configurando MockTeleBot.reply_to() para retornar um MockMessage com um message_id
@@ -218,9 +218,9 @@ class TestGDGAjuBot(unittest.TestCase):
 
         # Mensagens de grupo fazem link
         message.chat.type = "group"
-        g_bot._smart_reply(message, text)
+        g_bot._send_smart_reply(message, text)
         bot.reply_to.assert_called_with(message, text)
-        g_bot._smart_reply(message, text)
+        g_bot._send_smart_reply(message, text)
         bot.send_message.assert_called_with(message.chat.id, "Clique para ver a última resposta",
                                             reply_to_message_id=82)
 


### PR DESCRIPTION
Se em um grupo, solicitarem o mesmo comando em pouco tempo, o bot agora dá respostas mais bem humoradas que o seco "Clique para ver a última resposta".