### PR TITLE
Padroniza a mensagem enviada antes das mensagens automatizadas

### DIFF
--- a/gdgajubot/bot.py
+++ b/gdgajubot/bot.py
@@ -330,27 +330,28 @@ class GDGAjuBot:
                 schedule_job(between(3, 12))  # reschedule a job to some hours from now
                 return
 
-            # used to send an aware message before the book
-            say = None
+            # flag to know if the book should be sent
+            should_send = False
 
             # we should send if
             if passed.days >= 1:  # has passed 1 day or more since last book was sent
-                say = "⛺ Faz um tempão que não pedem o livro do dia, que bom que estou aqui!"
+                should_send = True
             elif count >= 25:  # passed 25 messages and 12 hours or more
                 if passed.seconds >= 12 * 3600:
-                    say = "💂 Ei, faz um tempo que mandei o livro do dia. Vou fazer agora!"
+                    should_send = True
                 elif count >= 100:  # passed 100 messages and 6 hours or more
                     if passed.seconds >= 6 * 3600:
-                        say = "☕ Não percam o livro do dia!!!"
+                        should_send = True
                     elif count >= 300:  # passed 300 messages and 3 hours or more
-                        say = "🏇 Passou um monte de mensagens, será que todos viram o livro do dia?"
+                        should_send = True
 
             # book should be sent now
-            if say:
-                self.bot.send_message(message.chat_id, f'_{say}_', parse_mode="Markdown")
+            if should_send:
+                self.warn_auto_message(message.chat_id)
                 self.packtpub_free_learning(message, now, reply=False)
                 logging.info("ensure_daily_book: sent to %s", message.chat.username)
                 schedule_job(between(12, 24))  # reschedule a job to a bunch of hours from now
+            # or no sending at the moment
             else:
                 hours = passed.seconds // 3600
                 schedule_job(between(1, 24 - hours))  # reschedule a job to a fair time
@@ -420,6 +421,9 @@ class GDGAjuBot:
             states = super().__getattribute__('states')  # get states without changing access status
             self.resources.update_states(states)
             access['count'] = 0
+
+    def warn_auto_message(self, chat_id):
+        self.bot.send_message(chat_id, '_👾 Mensagem automática do seu bot favorito._', parse_mode="Markdown")
 
     # used to keep track of self.states access
     def __getattribute__(self, name):

--- a/gdgajubot/bot.py
+++ b/gdgajubot/bot.py
@@ -330,20 +330,12 @@ class GDGAjuBot:
                 schedule_job(between(3, 12))  # reschedule a job to some hours from now
                 return
 
-            # flag to know if the book should be sent
-            should_send = False
-
-            # we should send if
-            if passed.days >= 1:  # has passed 1 day or more since last book was sent
-                should_send = True
-            elif count >= 25:  # passed 25 messages and 12 hours or more
-                if passed.seconds >= 12 * 3600:
-                    should_send = True
-                elif count >= 100:  # passed 100 messages and 6 hours or more
-                    if passed.seconds >= 6 * 3600:
-                        should_send = True
-                    elif count >= 300:  # passed 300 messages and 3 hours or more
-                        should_send = True
+            should_send = (                                     # we should send if
+                passed.days >= 1                                # has passed 1 day or more since last book was sent
+                or count >= 25 and passed.seconds >= 12 * 3600  # passed 25 messages and 12 hours or more
+                or count >= 100 and passed.seconds >= 6 * 3600  # passed 100 messages and 6 hours or more
+                or count >= 300                                 # passed 300 messages and 3 hours or more
+            )
 
             # book should be sent now
             if should_send:

--- a/gdgajubot/bot.py
+++ b/gdgajubot/bot.py
@@ -423,7 +423,11 @@ class GDGAjuBot:
             access['count'] = 0
 
     def warn_auto_message(self, chat_id):
-        self.bot.send_message(chat_id, '_👾 Mensagem automática do seu bot favorito._', parse_mode="Markdown")
+        text = random.choice((
+            '_👾 Mensagem automática do seu bot favorito._',
+            '_🤖 Mensagem automática do amigão_ [{me.name}](tg://user?id={me.id})'.format(me=self.get_me()),
+        ))
+        self.bot.send_message(chat_id, text, parse_mode="Markdown")
 
     # used to keep track of self.states access
     def __getattribute__(self, name):

--- a/gdgajubot/bot.py
+++ b/gdgajubot/bot.py
@@ -423,11 +423,11 @@ class GDGAjuBot:
             access['count'] = 0
 
     def warn_auto_message(self, chat_id):
-        text = random.choice((
-            '_👾 Mensagem automática do seu bot favorito._',
-            '_🤖 Mensagem automática do amigão_ [{me.name}](tg://user?id={me.id})'.format(me=self.get_me()),
+        random_text = random.choice((
+            lambda: '_👾 Mensagem automática do seu bot favorito._',
+            lambda: '_🤖 Mensagem automática do amigão_ [{me.name}](tg://user?id={me.id})'.format(me=self.get_me()),
         ))
-        self.bot.send_message(chat_id, text, parse_mode="Markdown")
+        self.bot.send_message(chat_id, random_text(), parse_mode="Markdown")
 
     # used to keep track of self.states access
     def __getattribute__(self, name):


### PR DESCRIPTION
O que muda visivelmente no comportamento atual é nas mensagens enviadas pelo bot antes do livro diário, a única automatizada, por enquanto.