### PR TITLE
Muda comportamento das easter eggs

### DIFF
--- a/gdgajubot/decorators.py
+++ b/gdgajubot/decorators.py
@@ -47,10 +47,11 @@ class on_message(BotDecorator):
         to_spam = kwargs.get('to_spam', True)
         instance = cls._instances_[target, to_spam]
 
+        search = re.compile(*args).search
         if not to_spam:
-            method = do_not_spam(method)
+            search = do_not_spam(search)
 
-        action = (re.compile(*args).search, method)
+        action = (search, method)
 
         try:
             instance['actions'] += (action,)


### PR DESCRIPTION
Agora as _easter eggs_ encontram as strings de forma não determinística.

Por exemplo, atualmente quando o bot encontra uma frase como

> python, java, ruby

sempre irá escolher a easter egg de "ruby" por é a primeira definida. Com a modificação feita, agora pode ser qualquer uma das três, mas ainda mantendo a característica de não fazer spam.