### PR TITLE
Configuração para desabilitar o daily book

### DIFF
--- a/gdgajubot/bot.py
+++ b/gdgajubot/bot.py
@@ -373,6 +373,18 @@ class GDGAjuBot:
 
         return super().__getattribute__(name)
 
+    @command('/daily_book', pass_args=True, admin=True)
+    def daily_book_management(self, message, args):
+        if len(args) != 1 or args[0] not in ('enabled', 'disabled'):
+            message.reply_text('Modo de usar inválido!\n\n'
+                               'Digite `/daily_book enabled|disabled` para ativar/desativar o livro diário automático',
+                               quote=True, parse_mode='Markdown')
+
+        new_status = args[0] == 'enabled'
+        self.resources.set_group(message.chat_id, message.chat.username, has_daily_book=new_status)
+
+        message.reply_text('Livro diário automático ' + ('ativado' if new_status else 'desativado'), quote=True)
+
     @command('/book')
     def packtpub_free_learning(self, message, now=None, reply=True):
         """Retorna o livro disponível no free-learning da editora PacktPub."""

--- a/gdgajubot/bot.py
+++ b/gdgajubot/bot.py
@@ -227,6 +227,11 @@ class GDGAjuBot:
                     self.ensure_daily_book(new_message(self.bot.get_chat(chat_id)), as_job=True)
             return
 
+        group = self.resources.get_group(message.chat_id, message.chat.username)
+        if not group.has_daily_book:
+            logging.warning("ensure_daily_book: disabled for @%s", message.chat.username)
+            return
+
         state = self.get_state('daily_book', message.chat_id)
         schedule_job = self.__daily_book_scheduler(state, message)
 

--- a/gdgajubot/data/database.py
+++ b/gdgajubot/data/database.py
@@ -87,6 +87,7 @@ class Message(db.Entity):
 class Group(db.Entity):
     telegram_id = orm.PrimaryKey(int, size=64)
     telegram_groupname = orm.Optional(str)
+    has_daily_book = orm.Optional(bool, default=False)
 
     def __str__(self):
         return 'Group - {}'.format(self.telegram_groupname)

--- a/gdgajubot/decorators.py
+++ b/gdgajubot/decorators.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from telegram.ext import CommandHandler, MessageHandler, Filters
 
-from gdgajubot.util import BotDecorator, bot_callback
+from gdgajubot.util import BotDecorator, bot_callback, bot_callback_with_args
 
 __all__ = ('do_not_spam', 'command', 'on_message', 'task', 'easter_egg')
 
@@ -21,16 +21,20 @@ def do_not_spam(func):
 
 class command(BotDecorator):
     _arguments_ = (1, ...)
-    _keywords_ = (0, 1)
+    _keywords_ = (0, 2)
 
     @classmethod
     def do_process(cls, target, method, dispatcher, *args, **kwargs):
         names = [(k[1:] if k[0] == '/' else k)
                  for k in args]
-        handler = CommandHandler(names, bot_callback(method))
 
-        from gdgajubot.bot import AdminFilter
+        if kwargs.get('pass_args'):
+            handler = CommandHandler(names, bot_callback_with_args(method), pass_args=True)
+        else:
+            handler = CommandHandler(names, bot_callback(method))
+
         if kwargs.get('admin', False):
+            from gdgajubot.bot import AdminFilter
             handler.filters = AdminFilter(names[0], target.resources)
 
         dispatcher.add_handler(handler)

--- a/gdgajubot/util.py
+++ b/gdgajubot/util.py
@@ -225,6 +225,10 @@ def bot_callback(method):
     return lambda bot, update: method(update.message)
 
 
+def bot_callback_with_args(method):
+    return lambda bot, update, args: method(update.message, args)
+
+
 class BotDecorator:
     _arguments_ = (0, ...)
     _keywords_ = (0, ...)


### PR DESCRIPTION
Adiciona item de configuração `has_daily_book` à tabela `Group` (pode ser necessário um _ALTER TABLE_ ou _DROP TABLE_ antes do deploy).

Adiciona também o comando administrativo `/daily_book`:

```
Ativar o livro diário automático para o grupo atual
> /daily_book enabled

Desativar o livro diário...
> /daily_book disabled
```