### PR TITLE
consertando /events e atualizando o readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ O bot atende aos seguintes comandos:
 - `/about`: Exibe informações sobre o bot.
 - `/events`: listagem dos próximos eventos registrados no meetup.
 - `/book`: livro gratuito do dia da editora [Packt Publishing](https://www.packtpub.com/).
+- `/udemy`: lista de cursos com cupons limitados de 100% de desconto do site [Udemy](https://www.udemy.com/).
 - `/list_users`: (admin) Lista todos os usuários.
 
 As seguintes funções estão disponíveis em `beta`:
@@ -59,16 +60,16 @@ Para isso, é necessário ter o `pipenv` instalado.
 ### Pré-requisitos
 
 Antes de começar, é necessário um token do Telegram [obtido com o @BotFather](https://core.telegram.org/bots#6-botfather),
-que vincula ao seu bot, e uma [chave do Meetup](https://secure.meetup.com/pt-BR/meetup_api/key/),
+que vincula ao seu bot, e o id do cliente, segredo do cliente e refresh token [obtidos ao seguir o passo 1 e 2 descrito em](https://www.meetup.com/pt-BR/meetup_api/auth/#oauth2),
 para ter permissões de acesso à API do Meetup.
 
 ### Iniciar o bot
 
 Para o bot ser iniciado, execute
 
-    $ gdgajubot -t 'TELEGRAM_TOKEN' -m 'MEETUP_KEY' -g 'GROUP_NAME'
+    $ gdgajubot -t 'TELEGRAM_TOKEN' -mcid 'MEETUP_CLIENT_ID' -mcs 'MEETUP_CLIENT_SECRET' -mrt 'MEETUP_REFRESH_TOKEN' -g 'GROUP_NAME'
 
-onde `TELEGRAM_TOKEN` é o token do seu bot, `MEETUP_KEY` a chave do Meetup e `GROUP_NAME` o nome do
+onde `TELEGRAM_TOKEN` é o token do seu bot, `MEETUP_CLIENT_ID` o id do cliente do Meetup, `MEETUP_CLIENT_SECRET` o segredo do cliente do Meetup, `MEETUP_REFRESH_TOKEN` o refresh token do Meetup e `GROUP_NAME` o nome do
 grupo do Meetup onde o bot irá buscar os eventos.
 
 No Windows, use:
@@ -78,7 +79,9 @@ No Windows, use:
 O bot também pode ser executado definindo variáveis de ambiente
 
     $ export TELEGRAM_TOKEN='token do bot'
-    $ export MEETUP_KEY='chave do meetup'
+    $ export MEETUP_CLIENT_ID='id do cliente do meetup'
+    $ export MEETUP_CLIENT_SECRET='segredo do cliente do meetup'
+    $ export MEETUP_REFRESH_TOKEN='refresh token do meetup'
     $ export GROUP_NAME='grupo do meetup'
     $ gdgajubot
 
@@ -94,4 +97,4 @@ Existe um parâmetro opcional que permite encurtar as URLs fornecidas pelo bot: 
 
 O `gdgajubot` é desenvolvido com testes automatizados, porém usando dados estáticos. Para verificar
 se o seu bot está funcionando de verdade, inicie uma conversa com ele com um cliente Telegram.
-Escreva `/events` ou `/book` e veja se ele responde.
+Escreva `/events`,`/book` ou `/udemy` e veja se ele responde.

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -3,7 +3,9 @@ events_source: meetup
 tokens:
   telegram: "TELEGRAM_TOKEN"
   facebook: "FACEBOOK_API_KEY"
-  meetup: "MEETUP_API_KEY"
+  meetup_client_id: "MEETUP_CLIENT_ID"
+  meetup_client_secret: "MEETUP_CLIENT_SECRET"
+  meetup_refresh_token: "MEETUP_REFRESH_TOKEN"
 links:
   link1: "url_1"
   link2: "url_2"

--- a/gdgajubot/__main__.py
+++ b/gdgajubot/__main__.py
@@ -27,8 +27,14 @@ def main():
         '-t', '--telegram_token',
         help='Token da API do Telegram')
     parser.add_argument(
-        '-m', '--meetup_key',
-        help='Key da API do Meetup')
+        '-mcid', '--meetup_client_id',
+        help='Client_id da API do Meetup')
+    parser.add_argument(
+        '-mcs', '--meetup_client_secret',
+        help='Client_secret da API do Meetup')
+    parser.add_argument(
+        '-mrt', '--meetup_refresh_token',
+        help='Refresh_token da API do Meetup')
     parser.add_argument(
         '-f', '--facebook_key',
         help='Key da API do Facebook')
@@ -57,7 +63,7 @@ def main():
 
     # Define the events source if needed
     if not _config.events_source:
-        if _config.meetup_key:
+        if _config.meetup_refresh_token:
             _config.events_source = 'meetup'
         elif _config.facebook_key:
             _config.events_source = 'facebook'

--- a/gdgajubot/data/resources.py
+++ b/gdgajubot/data/resources.py
@@ -59,20 +59,28 @@ class Resources:
 
     def meetup_events(self, n):
         """Obtém eventos do Meetup."""
-        # api v3 base url
+        url = 'https://secure.meetup.com/oauth2/access'
+        data = {
+            'client_id': self.config.meetup_client_id,
+            'client_secret': self.config.meetup_client_secret,
+            'grant_type': 'refresh_token',
+            'refresh_token': self.config.meetup_refresh_token,
+        }
+        token = requests.post(url, data = data).json()['access_token']
+        
         all_events = []
         for group in self.config.group_name:
             url = "https://api.meetup.com/{group}/events".format(
                 group=group
             )
 
-            # response for the events
-            r = requests.get(url, params={
-                'key': self.config.meetup_key,
-                'status': 'upcoming',
-                'only': 'name,time,link',  # filter response to these fields
+            params= {
+                'access_token': token,
+                'has_ended': False,
                 'page': n,                 # limit to n events
-            })
+            }
+            # response for the events
+            r = requests.get(url, params = params)
 
             # API output
             events = r.json()

--- a/gdgajubot/util.py
+++ b/gdgajubot/util.py
@@ -22,7 +22,9 @@ class BotConfig:
     def __init__(
         self,
         telegram_token=None,
-        meetup_key=None,
+        meetup_client_id=None,
+        meetup_client_secret=None,
+        meetup_refresh_token=None,
         facebook_key=None,
         database_url=None,
         group_name=None,
@@ -32,7 +34,9 @@ class BotConfig:
         config_file=None,
     ):
         self.telegram_token = telegram_token
-        self.meetup_key = meetup_key
+        self.meetup_client_id = meetup_client_id
+        self.meetup_client_secret = meetup_client_secret
+        self.meetup_refresh_token = meetup_refresh_token
         self.facebook_key = facebook_key
         self.group_name = group_name.split(',') if group_name else None
         self.url_shortener_key = url_shortener_key
@@ -57,7 +61,9 @@ class BotConfig:
         self.custom_responses = contents.get('custom_responses', None)
         if 'tokens' in contents:
             self.telegram_token = contents['tokens'].get('telegram', None)
-            self.meetup_key = contents['tokens'].get('meetup', None)
+            self.meetup_client_id = contents['tokens'].get('meetup_client_id', None)
+            self.meetup_client_secret = contents['tokens'].get('meetup_client_secret', None)
+            self.meetup_refresh_token = contents['tokens'].get('meetup_refresh_token', None)
             self.facebook_key = contents['tokens'].get('facebook', None)
         if 'database' in contents:
             self.database = contents['database']


### PR DESCRIPTION
A API do meetup (https://secure.meetup.com/meetup_api/key/) mudou para OAuth2 e agora são necessários mais argumentos para rodar o bot e conectá-lo com essa API.

Serão necessários o id do cliente, o segredo do cliente e o refresh token, todos disponíveis depois do passo 1 e passo 2 descritos em https://www.meetup.com/pt-BR/meetup_api/auth/#oauth2

> resources.py, util.py e __main__.py foram alterados para lidar com os novos argumentos.

> readme atualizado para entrar em acordo com as mudanças do último merge e novas mudanças

Exemplo de chamada:

gdgajubot -t 'TELEGRAM_TOKEN' -mcid 'MEETUP_CLIENT_ID' -mcs 'MEETUP_CLIENT_SECRET' -mrt 'MEETUP_REFRESH_TOKEN' -g 'GROUP_NAME'